### PR TITLE
added scm information to pom 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:imscaradh/srs.git</connection>
+        <developerConnection>scm:git:git@github.com:imscaradh/srs.git</developerConnection>
+    </scm>
+
     <developers>
         <developer>
             <id>hirtd2</id>


### PR DESCRIPTION
To release the project through maven-release-plugin, we have to provide the scm connection URL (in our case it points to Github). 